### PR TITLE
Remove unused deps

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -9,8 +9,9 @@ complete change log can be found in "CHANGES.md".
 
 BEFORE YOU BEGIN
 
-    You'll need ANSI-compliant C compiler, plus a make program and
-    POSIX-compliant shell (/bin/sh).  The GNU compiler tools and Bash work well
+    You'll need ANSI-compliant C compiler, a make program, POSIX-compliant
+    shell (/bin/sh) and programs needed for "autogen.sh" script - autoconf,
+    automake, autopoint and libtool. The GNU compiler tools and Bash work well
     and we have tested the current CUPS code against several versions of GCC
     with excellent results.
 
@@ -101,9 +102,25 @@ PACKAGING THE SOFTWARE FOR OPERATING SYSTEM DISTRIBUTIONS
     people. So it is highly recommended for desktop distributions and
     generally distributions with a CUPS printing stack.
 
-    In addition to the package itself cups-filters 2.x, liblouis,
-    ImageMagick, and poppler-utils need to be installed. Recommended
-    is to also have liblouisutdml, antiword, docx2txt for more
-    sophisticated Braille generation representing also the formatting
-    of the input text. None of these is needed for compiling
-    braille-printer-app.
+    In addition to the package itself several other packages can be
+    required based on packager's decision which file formats the Braille
+    printer application should support. The binaries, the formats they support
+    and possible package name are:
+
+    - lou_translate - for musicxml files and backup Braille translations,
+      from liblouis package,
+    - convert - for raster images, from ImageMagick,
+    - pdftotext - for PDFs, from poppler-utils,
+    - file2brl - for text files and best Braille translations,
+      from liblouisutdml,
+    - inkscape - for vector images, from inkscape,
+    - lynx - for html files, from lynx,
+    - antiword - for MS Word doc files, from antiword,
+    - cups-filters 2.x - for possible input file's conversion into
+      formats which Braille filters accept,
+    - docx2txt - for MS Word docx files,
+    - unzip - for OpenOffice/Libreoffice file conversions, from unzip,
+    - rtf2txt - for translating RTF files, from rtf2txt,
+    - FreeDots - for better translation of musicxml files, from FreeDots
+
+    None of these is needed for compiling braille-printer-app.

--- a/INSTALL
+++ b/INSTALL
@@ -9,7 +9,7 @@ complete change log can be found in "CHANGES.md".
 
 BEFORE YOU BEGIN
 
-    You'll need ANSI-compliant C and C++ compilers, plus a make program and
+    You'll need ANSI-compliant C compiler, plus a make program and
     POSIX-compliant shell (/bin/sh).  The GNU compiler tools and Bash work well
     and we have tested the current CUPS code against several versions of GCC
     with excellent results.
@@ -19,8 +19,8 @@ BEFORE YOU BEGIN
     Compaq, HP, SGI, and Sun.  BSD users should use GNU make (gmake) since BSD
     make does not support "include".
 
-    CUPS (2.2.2 or newer), libcupsfilters 2.x, and libppd must be
-    installed to be able to compile this package.
+    CUPS (2.2.2 or newer) development files must be installed to be able to compile
+    this package.
 
 COMPILING THE GIT REPOSITORY CODE
 

--- a/README.md
+++ b/README.md
@@ -17,14 +17,7 @@ Braille embosser support, currently only as a classic CUPS printer
 driver package. A conversion to a Printer Application is in the works
 and will get committed here soon.
 
-For compiling and using this package CUPS (2.2.2 or newer),
-libcupsfilters 2.x, and libppd are needed.
-
-You will also need at least cups-filters 2.x, liblouis, ImageMagick,
-and poppler-utils. Recommended is to also have liblouisutdml,
-antiword, docx2txt for more sophisticated Braille generation
-representing also the formatting of the input text. None of these is
-needed for compiling braille-printer-app.
+For compiling and using this package see INSTALL file.
 
 Report bugs to
 

--- a/configure.ac
+++ b/configure.ac
@@ -19,6 +19,7 @@ m4_include([m4/ax_compare_version.m4])
 m4_include([m4/basic-directories.m4])
 AM_INIT_AUTOMAKE([1.11 gnu dist-xz dist-bzip2 subdir-objects foreign])
 AM_SILENT_RULES([yes])
+AC_LANG([C])
 AC_CONFIG_HEADERS([config.h])
 # Extra defines for the config.h
 AH_BOTTOM([
@@ -49,8 +50,6 @@ AH_BOTTOM([
 # Find required base packages
 # ===========================
 AC_PROG_CC
-AC_PROG_CXX
-AX_CXX_COMPILE_STDCXX([11],[noext],[mandatory])
 AM_PROG_CC_C_O
 AM_ICONV
 AC_PROG_INSTALL

--- a/configure.ac
+++ b/configure.ac
@@ -19,7 +19,6 @@ m4_include([m4/ax_compare_version.m4])
 m4_include([m4/basic-directories.m4])
 AM_INIT_AUTOMAKE([1.11 gnu dist-xz dist-bzip2 subdir-objects foreign])
 AM_SILENT_RULES([yes])
-AC_LANG([C++])
 AC_CONFIG_HEADERS([config.h])
 # Extra defines for the config.h
 AH_BOTTOM([
@@ -54,7 +53,6 @@ AC_PROG_CXX
 AX_CXX_COMPILE_STDCXX([11],[noext],[mandatory])
 AM_PROG_CC_C_O
 AM_ICONV
-AC_PROG_CPP
 AC_PROG_INSTALL
 AC_PROG_LN_S
 AC_PROG_MAKE_SET


### PR DESCRIPTION
We don't require C++, libcupsfilters and libppd for now, and explain further the dependencies in INSTALL.