### PR TITLE
configure.ac: Add configure option for musicxml file support

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -147,6 +147,10 @@ endif
 # ======================
 genfilterscripts =
 pkgfilter_SCRIPTS = $(genfilterscripts)
+if ENABLE_MUSICXML
+musicxmlscripts = filter/musicxmltobrf
+endif
+
 if ENABLE_BRAILLE
 nodist_pkgfilter_SCRIPTS = \
 	driver/generic/brftoembosser \
@@ -158,7 +162,7 @@ nodist_pkgfilter_SCRIPTS = \
 	filter/vectortobrf \
 	filter/texttobrf \
 	filter/brftopagedbrf \
-	filter/musicxmltobrf
+	$(musicxmlscripts)
 endif
 
 distclean-local:

--- a/configure.ac
+++ b/configure.ac
@@ -188,6 +188,21 @@ PKG_CHECK_EXISTS([liblouis], [
 AM_CONDITIONAL(ENABLE_BRAILLE, test "x$enable_braille" = xyes)
 AC_SUBST(TABLESDIR)
 
+# ================
+# musicxml support
+# ================
+AC_ARG_ENABLE(musicxml, AS_HELP_STRING([--enable-musicxml],[enable musicxml file support, requires Freedots and lou_translate]),
+	      enable_musicxml=$enableval,enable_musicxml=no)
+if test "x$enable_musicxml" = "xyes"
+then
+	  MUSICXML_CONV="application/vnd.recordare.musicxml+xml application/vnd.cups-brf 30  musicxmltobrf"
+	  MUSICXML_TYPE="application/vnd.recordare.musicxml+xml xml contains(0,1000,\"<score-partwise\")"
+	  MUSICXML_FILTER="filter/musicxmltobrf"
+fi
+AM_CONDITIONAL(ENABLE_MUSICXML, test "x$enable_musicxml" = "xyes")
+AC_SUBST(MUSICXML_CONV)
+AC_SUBST(MUSICXML_TYPE)
+
 # =====================
 # Prepare all .in files
 # =====================
@@ -206,8 +221,10 @@ AC_CONFIG_FILES([
 	filter/brftopagedbrf
 	filter/vectortopdf
 	filter/vectortobrf
-	filter/musicxmltobrf
+	${MUSICXML_FILTER}
 	filter/liblouis1.defs.gen
+	mime/braille.convs
+	mime/braille.types
 ])
 AC_CONFIG_COMMANDS([executable-scripts], [
 	chmod +x filter/liblouis1.defs.gen
@@ -227,6 +244,7 @@ Build configuration:
 	cups-config:     ${with_cups_config}
 	braille:	 ${enable_braille}
 	braille tables:  ${TABLESDIR}
+	musicxml support:  ${enable_musicxml}
 	werror:          ${enable_werror}
 ==============================================================================
 ])

--- a/mime/braille.convs.in
+++ b/mime/braille.convs.in
@@ -16,7 +16,7 @@ application/sgml	application/vnd.cups-brf	10	texttobrf
 application/vnd.cups-brf	application/vnd.cups-paged-brf	0	brftopagedbrf
 application/vnd.cups-ubrl	application/vnd.cups-paged-ubrl	0	brftopagedbrf
 
-application/vnd.recordare.musicxml+xml application/vnd.cups-brf	30	musicxmltobrf
+@MUSICXML_CONV@
 
 application/vnd.oasis.opendocument.chart			application/vnd.cups-brf	30	texttobrf
 application/vnd.oasis.opendocument.formula			application/vnd.cups-brf	30	texttobrf

--- a/mime/braille.types.in
+++ b/mime/braille.types.in
@@ -16,7 +16,7 @@ application/vnd.cups-paged-ubrl
 
 application/sgml	sgml
 
-application/vnd.recordare.musicxml+xml xml contains(0,1000,"<score-partwise")
+@MUSICXML_TYPE@
 
 application/vnd.oasis.opendocument.chart					odc
 application/vnd.oasis.opendocument.database					odb


### PR DESCRIPTION
musicxml file support requires lou_translate and Freedots programs, where the latter is not available on some distributions. This configuration option will adjust MIME convs and types in case a maintainer can't ship non-functional filter when Freedots program is missing.