### PR TITLE
braille: Fix picking locale from newer liblouis files

### DIFF
--- a/filter/liblouis1.defs.gen.in
+++ b/filter/liblouis1.defs.gen.in
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# Copyright (c) 2015, 2017-2018, 2020 Samuel Thibault <samuel.thibault@ens-lyon.org>
+# Copyright (c) 2015, 2017-2018, 2020, 2024 Samuel Thibault <samuel.thibault@ens-lyon.org>
 #
 # Licensed under Apache License v2.0.  See the file "LICENSE" for more
 # information.
@@ -215,9 +215,12 @@ echo '  Choice "HyphLocale/Default hyphenation rules for language" ""'
 	"zh-hk")	LANGUAGE=Chinese LOCATION="Hong Kong" TYPE="grade 1" ;;
 	"zh-tw")	LANGUAGE=Chinese LOCATION="Taiwan" TYPE="grade 1" ;;
 	"zh-chn")	LANGUAGE=Chinese LOCATION="China" TYPE="grade 1" ;;
-	*)		locale=$(grep ^#+locale: "$i" | cut -d ':' -f 2-)
+	*)		locale=$(grep -e '^#+\(locale\|region\):' "$i" | cut -d ':' -f 2-)
+			language=$(grep ^#+language: "$i" | cut -d ':' -f 2-)
 			if [ -n "$locale" ]; then
 			  LANGUAGE="$locale"
+			elif [ -n "$language" ]; then
+			  LANGUAGE="$language"
 			fi
 			if [ $ext = ctb ]; then
 			  TYPE="contracted"


### PR DESCRIPTION
Since version 3.21.0 liblouis uses language/region instead of locale.